### PR TITLE
ensure proper request content type

### DIFF
--- a/vero/client.py
+++ b/vero/client.py
@@ -24,8 +24,7 @@ class VeroEventLogger(object):
 
     @classmethod
     def _fire_request(cls, endpoint, payload):
-        json_payload = json.dumps(payload)
-        return requests.request(endpoint.method, endpoint.url, data=json_payload, headers={'Content-Type': 'application/json'})
+        return requests.request(endpoint.method, endpoint.url, json=payload)
 
     def __init__(self, auth_token):
         self.auth_token = auth_token

--- a/vero/client.py
+++ b/vero/client.py
@@ -25,7 +25,7 @@ class VeroEventLogger(object):
     @classmethod
     def _fire_request(cls, endpoint, payload):
         json_payload = json.dumps(payload)
-        return requests.request(endpoint.method, endpoint.url, data=json_payload)
+        return requests.request(endpoint.method, endpoint.url, data=json_payload, headers={'Content-Type': 'application/json'})
 
     def __init__(self, auth_token):
         self.auth_token = auth_token


### PR DESCRIPTION
Requests to Vero were failing because of a wrong request content type.  Please merge and release an updated version on PyPi.