### PR TITLE
Remove development mode

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,6 @@ Use the authorization token from your Vero account page to create a VeroEventLog
     >>> logger = VeroEventLogger(auth_token)
 
 After creating an instance of VeroEventLogger as ``logger`` use any of the following methods to access Vero.
-All methods will accept the keyword argument ``development_mode=True`` to enable logging in test mode.
 
 Add user
 ~~~~~~~~

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -47,7 +47,6 @@ Use the authorization token from your Vero account page to create a VeroEventLog
     >>> logger = VeroEventLogger(auth_token)
 
 After creating an instance of VeroEventLogger as ``logger`` use any of the following methods to access Vero.
-All methods will accept the keyword argument ``development_mode=True`` to enable logging in test mode.
 
 Add user
 ~~~~~~~~

--- a/vero/client.py
+++ b/vero/client.py
@@ -30,14 +30,13 @@ class VeroEventLogger(object):
     def __init__(self, auth_token):
         self.auth_token = auth_token
 
-    def add_user(self, user_id, user_data, user_email=None, development_mode=False):
+    def add_user(self, user_id, user_data, user_email=None):
         """Add a new user and return the https request."""
         payload = {
             'auth_token': self.auth_token,
             'id': user_id,
             'email': user_email,
             'data': user_data,
-            'development_mode': development_mode
         }
         return self._fire_request(VeroEndpoints.ADD_USER, payload)
 
@@ -50,55 +49,50 @@ class VeroEventLogger(object):
         }
         return self._fire_request(VeroEndpoints.REIDENTIFY_USER, payload)
 
-    def edit_user(self, user_id, user_changes, development_mode=False):
+    def edit_user(self, user_id, user_changes):
         """Edit an existing user and return the https request."""
         payload = {
             'auth_token': self.auth_token,
             'id': user_id,
             'changes': user_changes,
-            'development_mode': development_mode
         }
         return self._fire_request(VeroEndpoints.EDIT_USER, payload)
 
-    def add_tags(self, user_id, tag_list, development_mode=False):
+    def add_tags(self, user_id, tag_list):
         """Add a list of tags for an existing user and return the https request."""
         payload = {
             'auth_token': self.auth_token,
             'id': user_id,
             'add': tag_list,
-            'development_mode': development_mode
         }
         return self._fire_request(VeroEndpoints.EDIT_TAGS, payload)
 
-    def remove_tags(self, user_id, tag_list, development_mode=False):
+    def remove_tags(self, user_id, tag_list):
         """Remove a list of tags for an existing user and return the https request."""
         payload = {
             'auth_token': self.auth_token,
             'id': user_id,
             'remove': tag_list,
-            'development_mode': development_mode
         }
         return self._fire_request(VeroEndpoints.EDIT_TAGS, payload)
 
-    def unsubscribe_user(self, user_id, development_mode=False):
+    def unsubscribe_user(self, user_id):
         """Unsubscribe an existing user and return the https request."""
         payload = {
             'auth_token': self.auth_token,
             'id': user_id,
-            'development_mode': development_mode
         }
         return self._fire_request(VeroEndpoints.UNSUBSCRIBE_USER, payload)
 
-    def resubscribe_user(self, user_id, development_mode=False):
+    def resubscribe_user(self, user_id):
         """Resubscribe an existing user and return the https request."""
         payload = {
             'auth_token': self.auth_token,
             'id': user_id,
-            'development_mode': development_mode
         }
         return self._fire_request(VeroEndpoints.RESUBSCRIBE_USER, payload)
 
-    def add_event(self, event_name, event_data, user_id, user_email=None, development_mode=False):
+    def add_event(self, event_name, event_data, user_id, user_email=None):
         """Add a new event and return the https request."""
         payload = {
             'auth_token': self.auth_token,
@@ -108,16 +102,14 @@ class VeroEventLogger(object):
                 'email': user_email
             },
             'data': event_data,
-            'development_mode': development_mode
         }
         return self._fire_request(VeroEndpoints.ADD_EVENT, payload)
 
-    def delete_user(self, user_id, development_mode=False):
+    def delete_user(self, user_id):
         """Delete an existing user and return the https request."""
         payload = {
             'auth_token': self.auth_token,
             'id': user_id,
-            'development_mode': development_mode
         }
         return self._fire_request(VeroEndpoints.DELETE_USER, payload)
 

--- a/vero/tests/client_test.py
+++ b/vero/tests/client_test.py
@@ -66,19 +66,9 @@ class VeroEventLoggerTests(unittest.TestCase):
 
         self.assertEqual(req.status_code, requests.codes.ok)
 
-    def test_add_user__development_mode(self):
-        req = self.logger.add_user(self.user_id, self.user_data, development_mode=True)
-
-        self.assertEqual(req.status_code, requests.codes.ok)
-
     def test_edit_user(self):
 
         req = self.logger.edit_user(self.user_id, self.user_changes)
-
-        self.assertEqual(req.status_code, requests.codes.ok)
-
-    def test_edit_user__development_mode(self):
-        req = self.logger.edit_user(self.user_id, self.user_changes, development_mode=True)
 
         self.assertEqual(req.status_code, requests.codes.ok)
 
@@ -92,11 +82,6 @@ class VeroEventLoggerTests(unittest.TestCase):
 
         self.assertEqual(req.status_code, requests.codes.bad)
 
-    def test_add_tags__development_mode(self):
-        req = self.logger.add_tags(self.user_id, self.user_tags, development_mode=True)
-
-        self.assertEqual(req.status_code, requests.codes.ok)
-
     def test_remove_tags(self):
         req = self.logger.remove_tags(self.user_id, self.user_tags)
 
@@ -106,11 +91,6 @@ class VeroEventLoggerTests(unittest.TestCase):
         req = self.logger.add_tags(self.user_id, [])
 
         self.assertEqual(req.status_code, requests.codes.bad)
-
-    def test_remove_tags__development_mode(self):
-        req = self.logger.remove_tags(self.user_id, self.user_tags, development_mode=True)
-
-        self.assertEqual(req.status_code, requests.codes.ok)
 
     def test_unsubscribe_user(self):
         req = self.logger.unsubscribe_user(self.user_id)
@@ -123,11 +103,6 @@ class VeroEventLoggerTests(unittest.TestCase):
 
         self.assertEqual(req.status_code, requests.codes.ok)
 
-    def test_unsubscribe_user__development_mode(self):
-        req = self.logger.unsubscribe_user(self.user_id, development_mode=True)
-
-        self.assertEqual(req.status_code, requests.codes.ok)
-
     def test_add_event(self):
         req = self.logger.add_event(self.event_name, self.event_data, self.user_id)
 
@@ -135,11 +110,6 @@ class VeroEventLoggerTests(unittest.TestCase):
 
     def test_add_event__with_email(self):
         req = self.logger.add_event(self.event_name, self.event_data, self.user_id, user_email=self.user_email)
-
-        self.assertEqual(req.status_code, requests.codes.ok)
-
-    def test_add_event__development_mode(self):
-        req = self.logger.add_event(self.event_name, self.event_data, self.user_id, development_mode=True)
 
         self.assertEqual(req.status_code, requests.codes.ok)
 


### PR DESCRIPTION
Will require a major version bump due to removal of keyword argument in public API. Despite it not having any effect on Vero itself, developers may have hardcoded `development_mode=[True|False]` in their codebases.