### PR TITLE
Modify VeroEndpoints.BASE_URL

### DIFF
--- a/vero/client.py
+++ b/vero/client.py
@@ -6,16 +6,17 @@ Endpoint = collections.namedtuple('Endpoint', ['method', 'url'])
 
 class VeroEndpoints(object):
     """Endpoints for Vero API calls."""
-    VERO_BASE_URL = 'https://api.getvero.com/'
-    ADD_USER = Endpoint(method='POST', url=VERO_BASE_URL + 'api/v2/users/track')
-    DELETE_USER = Endpoint(method='DELETE', url=VERO_BASE_URL + 'api/v2/users/delete')
-    REIDENTIFY_USER = Endpoint(method='PUT', url=VERO_BASE_URL + 'api/v2/users/reidentify')
-    EDIT_USER = Endpoint(method='PUT', url=VERO_BASE_URL + 'api/v2/users/edit')
-    EDIT_TAGS = Endpoint(method='PUT', url=VERO_BASE_URL + 'api/v2/users/tags/edit')
-    RESUBSCRIBE_USER = Endpoint(method='POST', url=VERO_BASE_URL + 'api/v2/users/resubscribe')
-    UNSUBSCRIBE_USER = Endpoint(method='POST', url=VERO_BASE_URL + 'api/v2/users/unsubscribe')
-    ADD_EVENT = Endpoint(method='POST', url=VERO_BASE_URL + 'api/v2/events/track')
-    HEARTBEAT = Endpoint(method='GET', url=VERO_BASE_URL + 'api/v2/heartbeat')
+    _BASE_URL = 'https://api.getvero.com/api/v2'
+
+    ADD_USER = Endpoint('POST', _BASE_URL + '/users/track')
+    DELETE_USER = Endpoint('DELETE', _BASE_URL + '/users/delete')
+    REIDENTIFY_USER = Endpoint('PUT', _BASE_URL + '/users/reidentify')
+    EDIT_USER = Endpoint('PUT', _BASE_URL + '/users/edit')
+    EDIT_TAGS = Endpoint('PUT', _BASE_URL + '/users/tags/edit')
+    RESUBSCRIBE_USER = Endpoint('POST', _BASE_URL + '/users/resubscribe')
+    UNSUBSCRIBE_USER = Endpoint('POST', _BASE_URL + '/users/unsubscribe')
+    ADD_EVENT = Endpoint('POST', _BASE_URL + '/events/track')
+    HEARTBEAT = Endpoint('GET', _BASE_URL + '/heartbeat')
 
 
 class VeroEventLogger(object):

--- a/vero/tests/client_test.py
+++ b/vero/tests/client_test.py
@@ -4,7 +4,7 @@ import vero
 
 __MOCK_AUTH_TOKEN__ = '__MOCK_AUTH_TOKEN__'
 __MOCK_REQUESTS__ = Mock()
-__BASE_URL__ = vero.client.VeroEndpoints.VERO_BASE_URL
+__BASE_URL__ = vero.client.VeroEndpoints._BASE_URL
 
 
 @patch('vero.client.requests.request', __MOCK_REQUESTS__)
@@ -39,7 +39,7 @@ class VeroEventLoggerTests(unittest.TestCase):
 
         __MOCK_REQUESTS__.assert_called_once_with(
             'POST',
-            __BASE_URL__ + 'api/v2/users/track',
+            __BASE_URL__ + '/users/track',
             json={
                 'auth_token': __MOCK_AUTH_TOKEN__,
                 'data': user_data,
@@ -56,7 +56,7 @@ class VeroEventLoggerTests(unittest.TestCase):
 
         __MOCK_REQUESTS__.assert_called_once_with(
             'PUT',
-            __BASE_URL__ + 'api/v2/users/reidentify',
+            __BASE_URL__ + '/users/reidentify',
             json={
                 'auth_token': __MOCK_AUTH_TOKEN__,
                 'new_id': new_user_id,
@@ -78,7 +78,7 @@ class VeroEventLoggerTests(unittest.TestCase):
 
         __MOCK_REQUESTS__.assert_called_once_with(
             'POST',
-            __BASE_URL__ + 'api/v2/users/track',
+            __BASE_URL__ + '/users/track',
             json={
                 'auth_token': __MOCK_AUTH_TOKEN__,
                 'data': user_data,
@@ -97,7 +97,7 @@ class VeroEventLoggerTests(unittest.TestCase):
 
         __MOCK_REQUESTS__.assert_called_once_with(
             'PUT',
-            __BASE_URL__ + 'api/v2/users/edit',
+            __BASE_URL__ + '/users/edit',
             json={
                 'auth_token': __MOCK_AUTH_TOKEN__,
                 'changes': user_changes,
@@ -113,7 +113,7 @@ class VeroEventLoggerTests(unittest.TestCase):
 
         __MOCK_REQUESTS__.assert_called_once_with(
             'PUT',
-            __BASE_URL__ + 'api/v2/users/tags/edit',
+            __BASE_URL__ + '/users/tags/edit',
             json={
                 'auth_token': __MOCK_AUTH_TOKEN__,
                 'add': user_tags,
@@ -129,7 +129,7 @@ class VeroEventLoggerTests(unittest.TestCase):
 
         __MOCK_REQUESTS__.assert_called_once_with(
             'PUT',
-            __BASE_URL__ + 'api/v2/users/tags/edit',
+            __BASE_URL__ + '/users/tags/edit',
             json={
                 'auth_token': __MOCK_AUTH_TOKEN__,
                 'add': [],
@@ -145,7 +145,7 @@ class VeroEventLoggerTests(unittest.TestCase):
 
         __MOCK_REQUESTS__.assert_called_once_with(
             'PUT',
-            __BASE_URL__ + 'api/v2/users/tags/edit',
+            __BASE_URL__ + '/users/tags/edit',
             json={
                 'auth_token': __MOCK_AUTH_TOKEN__,
                 'remove': user_tags,
@@ -161,7 +161,7 @@ class VeroEventLoggerTests(unittest.TestCase):
 
         __MOCK_REQUESTS__.assert_called_once_with(
             'PUT',
-            __BASE_URL__ + 'api/v2/users/tags/edit',
+            __BASE_URL__ + '/users/tags/edit',
             json={
                 'auth_token': __MOCK_AUTH_TOKEN__,
                 'remove': [],
@@ -176,7 +176,7 @@ class VeroEventLoggerTests(unittest.TestCase):
 
         __MOCK_REQUESTS__.assert_called_once_with(
             'POST',
-            __BASE_URL__ + 'api/v2/users/unsubscribe',
+            __BASE_URL__ + '/users/unsubscribe',
             json={
                 'auth_token': __MOCK_AUTH_TOKEN__,
                 'id': user_id,
@@ -190,7 +190,7 @@ class VeroEventLoggerTests(unittest.TestCase):
 
         __MOCK_REQUESTS__.assert_called_with(
             'POST',
-            __BASE_URL__ + 'api/v2/users/resubscribe',
+            __BASE_URL__ + '/users/resubscribe',
             json={
                 'auth_token': __MOCK_AUTH_TOKEN__,
                 'id': user_id,
@@ -209,7 +209,7 @@ class VeroEventLoggerTests(unittest.TestCase):
 
         __MOCK_REQUESTS__.assert_called_with(
             'POST',
-            __BASE_URL__ + 'api/v2/events/track',
+            __BASE_URL__ + '/events/track',
             json={
                 'auth_token': __MOCK_AUTH_TOKEN__,
                 'event_name': event_name,
@@ -234,7 +234,7 @@ class VeroEventLoggerTests(unittest.TestCase):
 
         __MOCK_REQUESTS__.assert_called_with(
             'POST',
-            __BASE_URL__ + 'api/v2/events/track',
+            __BASE_URL__ + '/events/track',
             json={
                 'auth_token': __MOCK_AUTH_TOKEN__,
                 'event_name': event_name,
@@ -253,7 +253,7 @@ class VeroEventLoggerTests(unittest.TestCase):
 
         __MOCK_REQUESTS__.assert_called_once_with(
             'DELETE',
-            __BASE_URL__ + 'api/v2/users/delete',
+            __BASE_URL__ + '/users/delete',
             json={
                 'auth_token': __MOCK_AUTH_TOKEN__,
                 'id': user_id,
@@ -265,5 +265,5 @@ class VeroEventLoggerTests(unittest.TestCase):
 
         __MOCK_REQUESTS__.assert_called_once_with(
             'GET',
-            __BASE_URL__ + 'api/v2/heartbeat',
+            __BASE_URL__ + '/heartbeat',
         )


### PR DESCRIPTION
Now named `VeroEndpoints._BASE_URL` and contains the `api/v2/` path prefix which is common to all endpoints.