### PR TITLE
Remove pin from dependencies

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,17 @@
 Vero Python
 ===========
 
+Version 2.0.1
+-------------
+
+Released on March 22, 2017
+
+- Removed pinned version from `requests` and `mock` dependencies
+
 Version 2.0.0
 -------------
 
-Released on February 29, 2015
+Released on February 29, 2016
 
 Breaking Changes
 

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,8 @@ except ImportError:
 packages = [
     'vero'
 ]
-requires = ['requests==2.7.0']
-tests_require = ['mock==1.0.1']
+requires = ['requests']
+tests_require = ['mock']
 
 setup(
     name='vero',

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     name='vero',
     description='Python wrapper for Vero API',
     long_description=open('README.rst').read(),
-    version='2.0.0',
+    version='2.0.1',
     author=open('AUTHORS.rst').read(),
     author_email='opensource@waveaccounting.com',
     url='https://github.com/waveaccounting/vero-python',


### PR DESCRIPTION
Fixes #26 by removing the pinned versions from our `setup.py` requirements.